### PR TITLE
Fix missing error message

### DIFF
--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -1033,6 +1033,8 @@ MSG
           show 'Unable to transfer to your next_sip_uri location', e
         end
       else
+        error_message = 'We are unable to connect to the fail over sip U R I.  Please try your call again later.'
+        @current_call.log "====> #{error_message} <===="
         @current_call.say error_message, :voice => @tropo_voice
         @current_call.hangup
       end


### PR DESCRIPTION
Without this error message, if you hit the failover code (and fail) you get an unhandled Java exception on the missing variable.
