### PR TITLE
'failed' metacall and better REST origination handling

### DIFF
--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -1198,7 +1198,7 @@ MSG
   # This class emulates the Tropo callObject object for the purposes of allowing
   # Tropo-AGItate to emulate Asterisk "h" (hangup) and "failed" special calls.
   class DeadCall
-    attr_accessor :callerID, :calledID, :callerName
+    attr_accessor :callerID, :calledID, :callerName, :id
 
     def initialize(system, destination, info)
       require 'digest/md5'

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -703,7 +703,8 @@ class TropoAGItate
       else
         response = @current_call.ask(@wait_for_digits_options['prompt'], @wait_for_digits_options)
       end
-      @agi_response + response.value[0].to_s + "\n"
+      digit = response.value.nil? ? 0 : response.value[0]
+      @agi_response + digit.to_s + "\n"
     rescue => e
       log_error(this_method, e)
     end

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -638,7 +638,7 @@ class TropoAGItate
       when 'get'
         varname = strip_quotes(options[:args][0].to_s)
         if @chanvars[varname]
-          @agi_response + '1 (' + @chanvars[varname] + ")\n"
+          @agi_response + '1 (' + @chanvars[varname].to_s + ")\n"
         else
           # Variable has not been set
           @agi_response + "0\n"

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -1260,7 +1260,7 @@ if @tropo_testing.nil?
     #  User may pass in AIM, GTALK, MSN, JABBER, TWITTER, SMS or YAHOO, SMS is default
     options[:network]  = $network || 'SMS'
     # Time tropo will wait before hanging up, default is 30
-    options[:timeout]  = $timeout if $timeout
+    options[:timeout]  = $timeout.to_i if $timeout
 
     # If voice turn the phone number into a Tel URI, but only if not a SIP URI
     $destination = 'tel:+' + $destination if options[:channel].downcase == 'voice' && $destination[0..2] != 'sip'

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -911,7 +911,7 @@ class TropoAGItate
   # @return [Boolean] whether the socket is open or not
   def run
     if create_socket_connection
-      while @current_call.isActive
+      until @agi_client.closed?
         begin
           command = @agi_client.gets
           show "Raw string: #{command}"

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -24,7 +24,7 @@ class Hash
       options
     end
   end
-  
+
   def symbolize_keys!
     self.replace(self.symbolize_keys)
   end
@@ -262,20 +262,20 @@ class TropoAGItate
     # @return [String] the response in AGI raw form
     def file(options={})
       check_state
-      
+
       @wait_for_digits_options = parse_input_string options[:args][0], 16
       if @wait_for_digits_options.nil?
         prompt, escape_digits = extract_prompt_and_escape_digits(options[:args][0])
-        
+
         asterisk_sound_url = fetch_asterisk_sound(prompt)
         prompt = asterisk_sound_url if asterisk_sound_url
-        
+
         if escape_digits.nil?
           @current_call.say prompt, :voice => @tropo_voice
           result = @agi_response + "0 endpos=0\n"
         else
           # Timeout is set to 0 so we return immediately after playback
-          response = @current_call.ask prompt, { :choices    => create_choices(escape_digits), 
+          response = @current_call.ask prompt, { :choices    => create_choices(escape_digits),
                                                  :choiceMode => 'keypad',
                                                  :timeout    => 0 }
           digit = response.value.nil? ? 0 : response.value[0]
@@ -399,26 +399,26 @@ class TropoAGItate
     # @return [String] the response in the AGI raw form
     def read(options={})
       check_state
-      
+
       # Check to see if the READ arguments were sent in quotes, like from Asterisk-Java
       options[:args] = options[:args][0].split(',', -4) if options[:args].length == 1
-      
+
       # Set defaults
       prompt, choices, attempts, timeout = 'silence', '[1-255 DIGITS]', 1, 30
-      
+
       # Set the prompt
       prompt = options[:args][1]  if options[:args][1] != ""
       asterisk_sound_url = fetch_asterisk_sound(prompt)
       prompt = asterisk_sound_url if asterisk_sound_url
-      
+
       # Set other values if provided
       choices = "[1-#{options[:args][2]} DIGITS]" unless options[:args][2].nil? || options[:args][2].empty?
       attempts = options[:args][4] unless options[:args][4].nil? || options[:args][4].empty?
       timeout = options[:args][5].to_f unless options[:args][5].nil? || options[:args][5].empty?
-      
+
       response = nil
       attempts.to_i.times do
-        response = @current_call.ask prompt, { :choices    => choices, 
+        response = @current_call.ask prompt, { :choices    => choices,
                                                :choiceMode => 'keypad',
                                                :terminator => '#',
                                                :timeout    => timeout }
@@ -429,7 +429,7 @@ class TropoAGItate
       @chanvars[options[:args][0]] = response.value
       @agi_response + "0\n"
     end
-    
+
     ##
     # Used to change the voice being used for speech recognition/ASR
     #
@@ -723,7 +723,7 @@ class TropoAGItate
     end
 
     private
-    
+
     ##
     # Automatically answers the call/session if not explicitly done
     def check_state
@@ -737,7 +737,7 @@ class TropoAGItate
       end
       true
     end
-    
+
     ##
     # Converts the choices passed in a STREAM FILE into the requisite comma-delimited format for Tropo
     #
@@ -752,7 +752,7 @@ class TropoAGItate
       end
       choices.chop
     end
-    
+
     ##
     # Extracts the prompt and escape digits from a STREAM FILE request
     #
@@ -766,7 +766,7 @@ class TropoAGItate
         return match_data.pre_match.rstrip, match_data[0]
       end
     end
-    
+
     ##
     # Returns the URI location of the Asterisk sound file if it is available
     #
@@ -915,8 +915,8 @@ class TropoAGItate
         begin
           command = @agi_client.gets
           show "Raw string: #{command}"
-          result = execute_command(command)
-          @agi_client.write(result)
+          result = execute_command command
+          @agi_client.write result
         rescue => e
           @current_call.log '====> Broken pipe to the AGI server, Adhearsion tends to drop the socket after sending a hangup. <===='
           show "Error is: #{e}"
@@ -934,15 +934,15 @@ class TropoAGItate
   # @return nil
   def create_socket_connection
     @current_call.log "Connecting to AGI server at #{@agi_uri.host}:#{@agi_uri.port}"
-    @agi_client = TCPSocket.new(@agi_uri.host, @agi_uri.port)
-    @agi_client.write(initial_message(@agi_uri.host, @agi_uri.port, @agi_uri.path[1..-1]))
+    @agi_client = TCPSocket.new @agi_uri.host, @agi_uri.port
+    @agi_client.write initial_message(@agi_uri.host, @agi_uri.port, @agi_uri.path[1..-1])
     true
   rescue => e
     # If we can not open the socket to the AGI server, play/log an error message and hangup the call
     error_message = 'We are unable to connect to the A G I server at this time, please try again later.'
     @current_call.log "====> #{error_message} <===="
     @current_call.log e
-    failover(@tropo_agi_config['tropo']['next_sip_uri'])
+    failover @tropo_agi_config['tropo']['next_sip_uri']
     false
   end
 
@@ -951,10 +951,7 @@ class TropoAGItate
   #
   # @return [Boolean] indicates if the socket is open or closed, true if closed, false if open
   def close_socket
-    begin
-      @agi_client.close
-    rescue => e
-    end
+    @agi_client.close rescue
     @agi_client.closed?
   end
 
@@ -1257,13 +1254,13 @@ if @tropo_testing.nil?
   if $destination
     options = {}
     # User may pass in the caller ID to use
-    options[:callerID]  = $caller_id if $caller_id
+    options[:callerID] = $caller_id if $caller_id
     # User may pass in text or voice to use for the channel
-    options[:channel]   = $channel || 'voice'
+    options[:channel]  = $channel || 'voice'
     #  User may pass in AIM, GTALK, MSN, JABBER, TWITTER, SMS or YAHOO, SMS is default
-    options[:network]   = $network || 'SMS'
+    options[:network]  = $network || 'SMS'
     # Time tropo will wait before hanging up, default is 30
-    options[:timeout]   = $timeout if $timeout
+    options[:timeout]  = $timeout if $timeout
 
     # If voice turn the phone number into a Tel URI, but only if not a SIP URI
     $destination = 'tel:+' + $destination if options[:channel].downcase == 'voice' && $destination[0..2] != 'sip'
@@ -1274,9 +1271,12 @@ if @tropo_testing.nil?
     result = call $destination, options
   end
 
-  if !$currentCall
+  if $currentCall
+    # This is a connected call
+    tropo_agi = TropoAGItate.new $currentCall, $currentApp
+  else
     # If the call failed, let the application know.
-    tropo_agi = TropoAGItate.new(TropoAGItate::DeadCall.new(self, options), $currentApp)
+    tropo_agi = TropoAGItate.new TropoAGItate::DeadCall.new(self, options), $currentApp
     tropo_agi.agi_exten = 'failed'
     log "Result: #{result.inspect}"
     tropo_agi.commands.chanvars['REASON'] = case result.name
@@ -1285,9 +1285,6 @@ if @tropo_testing.nil?
     when 'error'       then 8
     when 'callfailure' then 8
     end
-  else
-    # This is a connected call
-    tropo_agi = TropoAGItate.new($currentCall, $currentApp)
   end
 
   tropo_agi.agi_uri.path = $agi_path if $agi_path

--- a/lib/tropo.rb
+++ b/lib/tropo.rb
@@ -1,3 +1,22 @@
+# For testing outside of Tropo we need to mock the global methods
+# for logging and call management.
+module Tropo
+  def log(val)
+    #STDERR.puts val
+  end
+
+  def show(val)
+    log("====> #{val} <====")
+  end
+
+  def call
+    raise "Unimplemented!"
+  end
+end
+# Make these methods global.
+Object.send(:include, Tropo)
+@tropo_testing = true
+
 # Here for testing outside of Tropo, we need to mock the return on ask
 class AskResponse
   class Choice

--- a/lib/tropo.rb
+++ b/lib/tropo.rb
@@ -9,136 +9,141 @@ module Tropo
     log("====> #{val} <====")
   end
 
-  def call
+  def call(destination, options)
     raise "Unimplemented!"
+  end
+
+  class TropoEvent
+    attr_accessor :name, :recordURI, :choice, :attempt
+    # @value is sometimes set to an instance of TropoCall
+  end
+
+  # Here for testing outside of Tropo, we need to mock the return on ask
+  class AskResponse
+    class Choice
+      def concept
+        'zipcode'
+      end
+
+      def confidence
+        '10.0'
+      end
+
+      def interpretation
+        '94070'
+      end
+
+      def tag
+        nil
+      end
+    end
+
+    attr_reader :choice
+
+    def initialize
+      @choice = Choice.new
+    end
+
+    def value
+      '94070'
+    end
+  end
+
+  # Here for testing outside of Tropo, so we mock the $currentCall object
+  class CurrentCall
+    attr_reader :value
+    attr_reader :isActive
+    attr_reader :state
+    attr_reader :transferInfo
+
+    def initialize
+      @value = '94070'
+      @headers = {}
+      @isActive = true
+      @state = 'RINGING'
+    end
+
+    def answer; @state ='ANSWERED'; end
+    def ask(text, options); AskResponse.new; end
+    def callerID; '4155551212'; end
+    def calledID; '4045551234'; end
+    def callerName; 'Jason Goecke'; end
+    def call(text, options); 'call response: ' + text.inspect; p options; end
+    def conference(text); 'conference reponse: ' + text.inspect; end
+    def getHeader(header); @headers[header]; end
+
+    def hangup
+      @isActive = false
+      @state    = 'DISCONNECTED'
+    end
+
+    def id; '1234'; end
+    def log(text); text; end
+    def meetme(text, *rest); "meetme: #{text.inspect}, #{rest.inspect}"; end
+    def say(text, options); 'say response: text'; options; end
+    def setHeader(header, value); @headers[header] = value; end
+    def sipgetheader(calleridname); calleridname; end
+    def startCallRecording(uri, options); nil ; end
+    def stopCallRecording; nil; end
+    def state; 'RINGING'; end
+    def record(uri, options); true; end
+
+    def transfer(destinations, options)
+      @transferInfo = {:destinations => destinations, :options => options}
+      return TropoResult.new
+    end
+  end
+
+  class TropoResult
+    attr_accessor :name
+
+    def initialize
+      @name = 'transfer'
+    end
+  end
+
+  # Here for testing outside of Tropo, so we mock the $currentApp object
+  class CurrentApp
+    class GetApp
+      def getApp
+        'Application[http://hosting.tropo.com/49767/www/tropo-agi.rb:cus] ver(1.0.45500)'
+      end
+    end
+
+    def initialize(app_id = 49767)
+      @app_id = app_id
+    end
+
+    def self.app
+      GetApp.new
+    end
+
+    def baseDir
+      @cnt = 0 if @cnt.nil?
+
+      # This is only for testing JT!!!
+      case @app_id
+      when 49767
+        # Keep returning Windows format
+        'c:\tropo_app_home\49767'
+      when 49768
+        # Then return the Linux format for the last test
+        '/tropo_app_home/49768'
+      else
+        raise "Unknown application id!"
+      end
+    end
+  end
+
+  class IncomingCall
+    def getHeaderMap
+      map = java.util.HashMap.new
+      map.put "kermit", "green"
+      map.put "bigbird", "yellow"
+      map
+    end
   end
 end
 # Make these methods global.
 Object.send(:include, Tropo)
 @tropo_testing = true
-
-# Here for testing outside of Tropo, we need to mock the return on ask
-class AskResponse
-  class Choice
-    def concept
-      'zipcode'
-    end
-
-    def confidence
-      '10.0'
-    end
-
-    def interpretation
-      '94070'
-    end
-
-    def tag
-      nil
-    end
-  end
-
-  attr_reader :choice
-
-  def initialize
-    @choice = Choice.new
-  end
-
-  def value
-    '94070'
-  end
-end
-
-# Here for testing outside of Tropo, so we mock the $currentCall object
-class CurrentCall
-  attr_reader :value
-  attr_reader :isActive
-  attr_reader :state
-  attr_reader :transferInfo
-
-  def initialize
-    @value = '94070'
-    @headers = {}
-    @isActive = true
-    @state = 'RINGING'
-  end
-
-  def answer; @state ='ANSWERED'; end
-  def ask(text, options); AskResponse.new; end
-  def callerID; '4155551212'; end
-  def calledID; '4045551234'; end
-  def callerName; 'Jason Goecke'; end
-  def call(text, options); 'call response: ' + text.inspect; p options; end
-  def conference(text); 'conference reponse: ' + text.inspect; end
-  def getHeader(header); @headers[header]; end
-
-  def hangup
-    @isActive = false
-    @state    = 'DISCONNECTED'
-  end
-
-  def id; '1234'; end
-  def log(text); text; end
-  def meetme(text, *rest); "meetme: #{text.inspect}, #{rest.inspect}"; end
-  def say(text, options); 'say response: text'; options; end
-  def setHeader(header, value); @headers[header] = value; end
-  def sipgetheader(calleridname); calleridname; end
-  def startCallRecording(uri, options); nil ; end
-  def stopCallRecording; nil; end
-  def state; 'RINGING'; end
-  def record(uri, options); true; end
-
-  def transfer(destinations, options)
-    @transferInfo = {:destinations => destinations, :options => options}
-    return TropoResult.new
-  end
-end
-
-class TropoResult
-  attr_accessor :name
-
-  def initialize
-    @name = 'transfer'
-  end
-end
-
-# Here for testing outside of Tropo, so we mock the $currentApp object
-class CurrentApp
-  class GetApp
-    def getApp
-      'Application[http://hosting.tropo.com/49767/www/tropo-agi.rb:cus] ver(1.0.45500)'
-    end
-  end
-
-  def initialize(app_id = 49767)
-    @app_id = app_id
-  end
-
-  def self.app
-    GetApp.new
-  end
-
-  def baseDir
-    @cnt = 0 if @cnt.nil?
-
-    # This is only for testing JT!!!
-    case @app_id
-    when 49767
-      # Keep returning Windows format
-      'c:\tropo_app_home\49767'
-    when 49768
-      # Then return the Linux format for the last test
-      '/tropo_app_home/49768'
-    else
-      raise "Unknown application id!"
-    end
-  end
-end
-
-class IncomingCall
-  def getHeaderMap
-    map = java.util.HashMap.new
-    map.put "kermit", "green"
-    map.put "bigbird", "yellow"
-    map
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'agi_config'))
 
 RSpec.configure do |config|
   config.mock_with :flexmock
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
 end
 
 # NOTE!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'agi_config'))
 
-@tropo_testing = true
-%w(rubygems fakeweb eventmachine flexmock tropo-agitate lib/tropo yaml).each { |lib| require lib }
+%w(rubygems fakeweb eventmachine flexmock tropo tropo-agitate yaml).each { |lib| require lib }
 # em-spec/rspec Out for now since it is not Rspec 2.x compat
 
 RSpec.configure do |config|

--- a/spec/tropo-agitate_spec.rb
+++ b/spec/tropo-agitate_spec.rb
@@ -267,4 +267,28 @@ MSG
     flexmock(self).should_receive(:call).with("tel:+#{$destination}", options).and_return response
     @tropo_agitate = agitate_factory
   end
+
+  it 'should send a "failed" call when dial results in an error' do
+    # Simulate parameters passed as query string variables
+    $currentCall = nil
+    $destination = 'XXX'
+    $caller_id   = '14155551234'
+    $timeout     = '47'
+
+    options = {:callerID => $caller_id,
+               :timeout => $timeout.to_i,
+               :channel => 'voice',
+               :network => 'SMS'}
+
+    # Test the origination
+    response = TropoEvent.new
+    response.name = 'error'
+    flexmock(self).should_receive(:call).with("tel:+#{$destination}", options).and_return response
+    @tropo_agitate = agitate_factory
+
+    agi_environment = @tropo_agitate.initial_message('127.0.0.1', 1, 'example').split("\n")
+    agi_environment.grep(/agi_extension/)[0].match(/^agi_extension: (.*)$/)[1].should == 'failed'
+
+    @tropo_agitate.execute_command('GET VARIABLE REASON').should == "200 result=1 (8)\n"
+  end
 end

--- a/spec/tropo-agitate_spec.rb
+++ b/spec/tropo-agitate_spec.rb
@@ -33,7 +33,7 @@ describe "TropoAGItate" do
       h.should == { :foo => 'yes', :bar => 'no' }
     end
   end
-  
+
   it "should create a properly formatted initial message" do
     agi_uri  = URI.parse @tropo_agitate.tropo_agi_config['agi']['uri_for_local_tests']
     message  = @tropo_agitate.initial_message(agi_uri.host, agi_uri.port, agi_uri.path[1..-1])
@@ -55,7 +55,7 @@ agi_callingtns: 0
 agi_dnid: #{@current_call.calledID}
 agi_rdnis: unknown
 agi_context: #{agi_uri.path[1..-1]}
-agi_extension: 1
+agi_extension: s
 agi_priority: 1
 agi_enhanced: 0.0
 agi_accountcode: 0
@@ -208,26 +208,26 @@ MSG
     command = @tropo_agitate.execute_command('GET VARIABLE "FOOBAR"')
     command.should == "200 result=1 (green)\n"
   end
-  
+
   it "should execute the command as Asterisk-Java would pass" do
     command = @tropo_agitate.execute_command('EXEC "playback" "tt-monkeys"')
     command.should == "200 result=0\n"
-    
+
     command = @tropo_agitate.execute_command('STREAM FILE "tt-monkeys" "1234567890*#"')
     command.should == "200 result=57 endpos=0\n"
   end
-  
+
   it "should handle the STREAM FILE requests" do
     command = @tropo_agitate.execute_command('STREAM FILE tt-monkeys 1234567890*#')
     command.should == "200 result=57 endpos=0\n"
-    
+
     command = @tropo_agitate.execute_command('STREAM FILE tt-monkeys')
     command.should == "200 result=0 endpos=0\n"
-    
+
     command = @tropo_agitate.execute_command('STREAM STREAMFILE tt-monkeys 1234567890*#')
     command.should == "200 result=57 endpos=0\n"
   end
-  
+
   it "should return the account data from a directory lookup on Windows" do
     TropoAGItate.new(@current_call, CurrentApp.new(49767)).fetch_account_data[1].should == '49767'
   end
@@ -237,7 +237,7 @@ MSG
                          :body => File.open('tropo_agi_config/tropo_agi_config.yml').read)
     TropoAGItate.new(@current_call, CurrentApp.new(49768)).fetch_account_data[1].should == '49768'
   end
-  
+
   it "should execute a read" do
     command = @tropo_agitate.execute_command('EXEC READ pin,tt monkeys,5,,3,10')
     command.should == "200 result=0\n"

--- a/spec/tropo-agitate_spec.rb
+++ b/spec/tropo-agitate_spec.rb
@@ -248,4 +248,23 @@ MSG
     command = @tropo_agitate.execute_command('EXEC READ pin,tt monkeys,5,,3,10')
     command.should == "200 result=0\n"
   end
+
+  it 'should properly dial an outbound call when invoked via REST' do
+    # Simulate parameters passed as query string variables
+    $currentCall = nil
+    $destination = '14045556789'
+    $caller_id   = '14155551234'
+    $timeout     = '47'
+
+    options = {:callerID => $caller_id,
+               :timeout => $timeout.to_i,
+               :channel => 'voice',
+               :network => 'SMS'}
+
+    # Test the origination
+    response = TropoEvent.new
+    response.name = 'answer'
+    flexmock(self).should_receive(:call).with("tel:+#{$destination}", options).and_return response
+    @tropo_agitate = agitate_factory
+  end
 end

--- a/spec/tropo-agitate_spec.rb
+++ b/spec/tropo-agitate_spec.rb
@@ -20,6 +20,11 @@ describe "TropoAGItate" do
     $currentCall   = CurrentCall.new
     $currentApp    = CurrentApp.new
     $incomingCall  = IncomingCall.new
+    $destination   = nil
+    $caller_id     = nil
+    $timeout       = nil
+    $network       = nil
+    $channel       = nil
     @tropo_agitate = agitate_factory
   end
 


### PR DESCRIPTION
Using the HTTP REST API for call origination via AGItate, I needed a way to get feedback from Tropo whether the call was successful.  Fortunately, Asterisk has a special extension called 'failed' that can be used to signal a failed origination attempt.  This pull request implements the necessary plumbing to generated these 'failed' meta-calls.

To get this to work I needed to create a mock class called DeadCall providing the same interface as Tropo::TropoCall (usually presented as $currentCall).  This is because Tropo does not provide an active $currentCall instance when there is no real active call, yet I needed to be able to store and retrieve channel variables.

While adding unit tests for this new feature, I also restructured the tests to namespace the mocked objects to a Tropo class, just like the real thing.  Also, the unit tests now cover the HTTP REST origination logic, both success and failure.
