### PR TITLE
Fix compatibility with Asterisk MixMonitor

### DIFF
--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -904,10 +904,12 @@ class TropoAGItate
           show "Raw string: #{command}"
           result = execute_command command
           @agi_client.write result
+        rescue Errno::EPIPE
+          show 'AGI socket closed by client.'
         rescue => e
-          @current_call.log '====> Broken pipe to the AGI server, Adhearsion tends to drop the socket after sending a hangup. <===='
           show "Error Class: #{e.class.inspect}"
           show "Error is: #{e}"
+        ensure
           @current_call.hangup
           break
         end

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -343,14 +343,27 @@ class TropoAGItate
     # @return [String] the response in AGI raw form
     def monitor(options={})
       check_state
-
-      @current_call.startCallRecording options[:args]['uri'], options[:args]
+      @current_call.startCallRecording options[:args].first
       @agi_response + "0\n"
     rescue => e
       log_error(this_method, e)
     end
     alias :mixmonitor :monitor
-    alias :startcallrecording :monitor
+
+    ##
+    # Tropo-native method to record a call
+    # Tropo: https://www.tropo.com/docs/scripting/startcallrecording.htm
+    #
+    # @param [Hash] options used to build the startCallRecording
+    #
+    # @return [String] the response in AGI raw form
+    def startcallrecording(options={})
+      check_state
+      @current_call.startCallRecording options[:args].delete('uri'), options[:args]
+      @agi_response + "0\n"
+    rescue => e
+      log_error(this_method, e)
+    end
 
     ##
     # Initiates a playback to the Tropo call object for Speech Synthesis/TTS

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -610,8 +610,7 @@ class TropoAGItate
     #
     # @return [String] the AGI response
     def stopcallrecording(options={})
-      check_state
-
+      # This command is permissible on a dead channel.
       @current_call.stopCallRecording
       @agi_response + "0\n"
     rescue => e

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -972,7 +972,7 @@ agi_callingpres: 0
 agi_callingani2: 0
 agi_callington: 0
 agi_callingtns: 0
-agi_dnid: #{@current_call.calledID}
+agi_dnid: #{@current_call.calledID.gsub(/^tel:\+/, '')}
 agi_rdnis: #{rdnis}
 agi_context: #{agi_context}
 agi_extension: #{@agi_exten}

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -906,8 +906,10 @@ class TropoAGItate
           @agi_client.write result
         rescue => e
           @current_call.log '====> Broken pipe to the AGI server, Adhearsion tends to drop the socket after sending a hangup. <===='
+          show "Error Class: #{e.class.inspect}"
           show "Error is: #{e}"
           @current_call.hangup
+          break
         end
       end
       close_socket

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -961,10 +961,10 @@ class TropoAGItate
 agi_network: yes
 agi_network_script: #{agi_context}
 agi_request: agi://#{agi_host}:#{agi_port}/#{agi_context}
-agi_channel: TROPO/#{@current_call.id}
+agi_channel: TROPO/#{@current_call.sessionId}
 agi_language: en
 agi_type: TROPO
-agi_uniqueid: #{@current_call.id}
+agi_uniqueid: #{@current_call.sessionId}
 agi_version: tropo-agi-0.1.0
 agi_callerid: #{@current_call.callerID}
 agi_calleridname: #{@current_call.callerName}
@@ -1197,7 +1197,7 @@ MSG
   # This class emulates the Tropo callObject object for the purposes of allowing
   # Tropo-AGItate to emulate Asterisk "h" (hangup) and "failed" special calls.
   class DeadCall
-    attr_accessor :callerID, :calledID, :callerName, :id
+    attr_accessor :callerID, :calledID, :callerName, :sessionId
 
     def initialize(system, destination, info)
       require 'digest/md5'
@@ -1205,7 +1205,7 @@ MSG
       # Proxy object to the global namespace
       @system = system
       # Fake a channel ID since we don't have a real channel to provide one
-      @id         = Digest::MD5.hexdigest(self.hash.to_s + Time.now.usec.to_s)
+      @sessionId  = Digest::MD5.hexdigest(self.hash.to_s + Time.now.usec.to_s)
       @callerID   = info[:callerID]
       @calledID   = destination
       @callerName = info[:callerName] || ""

--- a/lib/tropo.rb
+++ b/lib/tropo.rb
@@ -83,7 +83,7 @@ module Tropo
     def say(text, options); 'say response: text'; options; end
     def setHeader(header, value); @headers[header] = value; end
     def sipgetheader(calleridname); calleridname; end
-    def startCallRecording(uri, options); nil ; end
+    def startCallRecording(uri, options={}); nil ; end
     def stopCallRecording; nil; end
     def state; 'RINGING'; end
     def record(uri, options); true; end

--- a/lib/tropo.rb
+++ b/lib/tropo.rb
@@ -77,7 +77,7 @@ module Tropo
       @state    = 'DISCONNECTED'
     end
 
-    def id; '1234'; end
+    def sessionId; '1234'; end
     def log(text); text; end
     def meetme(text, *rest); "meetme: #{text.inspect}, #{rest.inspect}"; end
     def say(text, options); 'say response: text'; options; end

--- a/spec/tropo-agitate_spec.rb
+++ b/spec/tropo-agitate_spec.rb
@@ -126,8 +126,11 @@ MSG
     command = @tropo_agitate.parse_command('GET VARIABLE "myvar"')
     command.should == { :command => "variable", :action => "get", :args => ["myvar"] }
 
-    command = @tropo_agitate.parse_command('EXEC monitor "{"method":"POST","uri":"http://localhost"}"')
-    command.should == { :command => "monitor", :action => "exec", :args => { 'method' => 'POST', 'uri' => 'http://localhost' } }
+    command = @tropo_agitate.parse_command('EXEC monitor "http://localhost"')
+    command.should == { :command => "monitor", :action => "exec", :args => [ 'http://localhost' ] }
+
+    command = @tropo_agitate.parse_command('EXEC startcallrecording "{"method":"POST","uri":"http://localhost"}"')
+    command.should == { :command => "startcallrecording", :action => "exec", :args => { 'method' => 'POST', 'uri' => 'http://localhost' } }
 
     command = @tropo_agitate.parse_command('EXEC mixmonitor "{"method":"POST","uri":"http://localhost"}"')
     command.should == { :command => "mixmonitor", :action => "exec", :args => { 'method' => 'POST', 'uri' => 'http://localhost' } }
@@ -180,7 +183,7 @@ MSG
     command = @tropo_agitate.execute_command('EXEC MeetMe "1234","d",""')
     command.should == "200 result=0\n"
 
-    command = @tropo_agitate.execute_command("EXEC monitor #{{ 'method' => 'POST', 'uri' => 'http://localhost' }.to_json}")
+    command = @tropo_agitate.execute_command("EXEC startcallrecording #{{ 'method' => 'POST', 'uri' => 'http://localhost' }.to_json}")
     command.should == "200 result=0\n"
 
     command = @tropo_agitate.execute_command('EXEC voice "simon"')

--- a/spec/tropo-agitate_spec.rb
+++ b/spec/tropo-agitate_spec.rb
@@ -47,10 +47,10 @@ describe "TropoAGItate" do
 agi_network: yes
 agi_network_script: #{agi_uri.path[1..-1]}
 agi_request: agi://#{agi_uri.host}:#{agi_uri.port}#{agi_uri.path}
-agi_channel: TROPO/#{$currentCall.id}
+agi_channel: TROPO/#{$currentCall.sessionId}
 agi_language: en
 agi_type: TROPO
-agi_uniqueid: #{$currentCall.id}
+agi_uniqueid: #{$currentCall.sessionId}
 agi_version: tropo-agi-0.1.0
 agi_callerid: #{$currentCall.callerID}
 agi_calleridname: #{$currentCall.callerName}

--- a/spec/tropo-commands_spec.rb
+++ b/spec/tropo-commands_spec.rb
@@ -90,13 +90,17 @@ describe "TropoAGItate::TropoCommands" do
     @tropo_commands.record(options).should == "200 result=0\n"
   end
 
-  it "should return a valid string when we reqeust a monitor/mixmonitor/startcallrecording" do
+  it "should return a valid string when we reqeust a monitor/mixmonitor" do
+    options = {:args => ['http://localhost/save_recording']}
+    @tropo_commands.monitor(options).should == "200 result=0\n"
+    @tropo_commands.mixmonitor(options).should == "200 result=0\n"
+  end
+
+  it "should return a valid string when we reqeust a startcallrecording" do
     options = { :args => { "uri"                 => "http://localhost/post_audio_to_s3?filename=voicemail.mp3",
                            "method"              => "POST",
                            "format"              => "mp3",
                            "transcriptionOutURI" => "mailto:jsgoecke@voxeo.com"} }
-    @tropo_commands.monitor(options).should == "200 result=0\n"
-    @tropo_commands.mixmonitor(options).should == "200 result=0\n"
     @tropo_commands.startcallrecording(options).should == "200 result=0\n"
   end
 


### PR DESCRIPTION
This pull request separates Monitor/MixMonitor from Tropo's native startCallRecording.  The existing startCallRecording method still takes JSON arguments so the enhanced functionality is available.  MixMonitor respects the Asterisk syntax so is compatible with existing AGI applications.

Also, we now use the sessionID for the channel unique variable.  This allows AGI applications to use the unique ID to send REST events to Tropo by referencing the channel unique ID.

Finally, some additional safety was added to avoid infinite loops on the socket read loop.
