### PR TITLE
Updating startCallRecording

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.1.3)
+    eventmachine (0.12.10)
+    eventmachine (0.12.10-java)
+    fakeweb (1.3.0)
+    flexmock (0.9.0)
+    json (1.5.4)
+    json (1.5.4-java)
+    rcov (0.9.10)
+    rcov (0.9.10-java)
+    rspec (2.6.0)
+      rspec-core (~> 2.6.0)
+      rspec-expectations (~> 2.6.0)
+      rspec-mocks (~> 2.6.0)
+    rspec-core (2.6.4)
+    rspec-expectations (2.6.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.6.0)
+
+PLATFORMS
+  java
+  ruby
+
+DEPENDENCIES
+  eventmachine
+  fakeweb
+  flexmock
+  json
+  rcov
+  rspec (>= 2.0.0)

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -470,7 +470,7 @@ class TropoAGItate
     def startcallrecording(options={})
       check_state
 
-      @current_call.startCallRecording options.delete('uri'), options
+      @current_call.startCallRecording options.delete(:uri), options
       AGI_SUCCESS_PREFIX + "0\n"
     rescue => e
       log_error(this_method, e)


### PR DESCRIPTION
I noticed the other day when I was trying to record calls that it was dropping the uri off of the request when passing it through.

Looks like when the hashes were changed to make all the string keys into symbol keys the startCallRecording method wasn't updated, so it was trying to delete out the uri using the old string key.

Tiny fix, but I thought I'd pass it back.
