### PR TITLE
Updating startCallRecording Round 2!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .bundle
+Gemfile.lock

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -470,7 +470,7 @@ class TropoAGItate
     def startcallrecording(options={})
       check_state
 
-      @current_call.startCallRecording options.delete('uri'), options
+      @current_call.startCallRecording options.delete(:uri), options
       AGI_SUCCESS_PREFIX + "0\n"
     rescue => e
       log_error(this_method, e)


### PR DESCRIPTION
I noticed the other day when I was trying to record calls that it was dropping the uri off of the request when passing it through.

Looks like when the hashes were changed to make all the string keys into symbol keys the startCallRecording method wasn't updated, so it was trying to delete out the uri using the old string key.

Tiny fix, but I thought I'd pass it back.

(Also updated the .gitignore to include Gemfile.lock)
