### PR TITLE
If AGI doesnt pass a timeout then Agitate defaults to setting a 0 timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development do
   gem 'rspec', '>= 2.0.0'
   gem 'flexmock'
   gem 'fakeweb'
-  #gem 'rcov'
+  gem 'rcov'
   #gem 'em-spec'
   gem 'ci_reporter'
   gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development do
   gem 'rspec', '>= 2.0.0'
   gem 'flexmock'
   gem 'fakeweb'
-  gem 'rcov'
+  #gem 'rcov'
   #gem 'em-spec'
   gem 'ci_reporter'
   gem 'rake'

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -199,7 +199,7 @@ class TropoAGItate
       show("______| #{p options} |______" )
       show("______| #{args.count} |______" )
       # Convert Asterisk app_dial inputs to Tropo syntax
-      options[:timeout]  = args.count.eql?(0) ? 30 : args.shift.to_i
+      options[:timeout]  = args[0].empty? ? 30 : args.shift.to_i
 
       # TODO: We may want to provide some compatibility with Asterisk dial flags
       # like m for MOH, A() to play announcement to called party,

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -196,7 +196,8 @@ class TropoAGItate
 
       destinations = parse_destinations(destinations.split('&'))
       options = {}
-
+      show("______| #{p options} |______" )
+      show("______| #{args.count} |______" )
       # Convert Asterisk app_dial inputs to Tropo syntax
       options[:timeout]  = args.count.eql?(0) ? 30 : args.shift.to_i
 

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -196,8 +196,6 @@ class TropoAGItate
 
       destinations = parse_destinations(destinations.split('&'))
       options = {}
-      show("______| #{p options} |______" )
-      show("______| #{args.count} |______" )
       # Convert Asterisk app_dial inputs to Tropo syntax
       options[:timeout]  = args[0].empty? ? 30 : args.shift.to_i
 

--- a/lib/tropo-agitate.rb
+++ b/lib/tropo-agitate.rb
@@ -198,7 +198,7 @@ class TropoAGItate
       options = {}
 
       # Convert Asterisk app_dial inputs to Tropo syntax
-      options[:timeout]  = args.shift.to_i if args.count
+      options[:timeout]  = args.count.eql?(0) ? 30 : args.shift.to_i
 
       # TODO: We may want to provide some compatibility with Asterisk dial flags
       # like m for MOH, A() to play announcement to called party,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'agi_config'))
 
-%w(rubygems rcov rspec fakeweb eventmachine flexmock tropo tropo-agitate yaml).each { |lib| require lib }
+%w(rubygems rspec fakeweb eventmachine flexmock tropo tropo-agitate yaml).each { |lib| require lib }
 # em-spec/rspec Out for now since it is not Rspec 2.x compat
 
 RSpec.configure do |config|

--- a/spec/tropo-agitate_spec.rb
+++ b/spec/tropo-agitate_spec.rb
@@ -140,7 +140,7 @@ MSG
         @tropo_agitate.execute_command('ANSWER').should == "200 result=0\n"
       end
     end
-    
+
     describe 'ASYNC AGI BREAK' do
       it 'should be an error' do
         expect { @tropo_agitate.execute_command('ASYNC AGI BREAK') }.to raise_error TropoAGItate::NonsenseCommand
@@ -207,11 +207,11 @@ MSG
         result = @tropo_agitate.execute_command('EXEC recognizer "en-us"')
         result.should == "200 result=0\n"
       end
-      
+
       describe 'ASK' do
-        it 'should properly parse the AGI input' do          
+        it 'should properly parse the AGI input' do
           flexmock($currentCall).should_receive(:ask).once.and_return AskResponse.new
-          
+
           result = @tropo_agitate.execute_command("EXEC ask #{ { :prompt => "Which is your favorite muppets character?", :choices => "kermit, fozzie, statler, waldorf, oscar, bert, ernie, swedish chef", :attempts => 3, :timeout => 10}.to_json }")
           result.should == "200 result={\"concept\":\"zipcode\",\"confidence\":\"10.0\",\"interpretation\":\"94070\",\"tag\":null}\n"
         end
@@ -695,6 +695,11 @@ MSG
       it 'should properly parse the input' do
         command = @tropo_agitate.parse_command('EXEC Dial "sip:jsgoecke@yahoo.com","",""')
         command.should == { :command => "dial", :action => "exec", :args => ['sip:jsgoecke@yahoo.com','',''] }
+      end
+
+      it 'should set default timeout of 30 if no second argument is passed' do
+        command = @tropo_agitate.parse_command('EXEC Dial "sip:jsgoecke@yahoo.com","",""')
+        command.should == { :command => "dial", :action => "exec", :args => ['sip:jsgoecke@yahoo.com','30',''] }
       end
 
       it 'should properly parse a telephone number dial string' do

--- a/spec/tropo-agitate_spec.rb
+++ b/spec/tropo-agitate_spec.rb
@@ -697,9 +697,9 @@ MSG
         command.should == { :command => "dial", :action => "exec", :args => ['sip:jsgoecke@yahoo.com','',''] }
       end
 
-      it 'should set default timeout of 30 if no second argument is passed' do
+      it 'should set default timeout of 30 seconds if 2nd argement is empty' do
         command = @tropo_agitate.parse_command('EXEC Dial "sip:jsgoecke@yahoo.com","",""')
-        command.should == { :command => "dial", :action => "exec", :args => ['sip:jsgoecke@yahoo.com','30',''] }
+        command.should == { :action => "exec", :command => "dial", :args => ['sip:jsgoecke@yahoo.com','30',''] }
       end
 
       it 'should properly parse a telephone number dial string' do


### PR DESCRIPTION
If AGI doesn't pass a timeout then Agitate defaults to setting a 0 timeout which means the call actually times out at 0 seconds ( yea thats not going to work ).  If a timeout is not passed we should omit the timeout entirely or set it to 30 seconds, which is the platform default 
